### PR TITLE
Skip the babel platform polyfill

### DIFF
--- a/app/components/mig/me/me.js
+++ b/app/components/mig/me/me.js
@@ -1,6 +1,6 @@
 /*global HTMLElement */
 import insertCss from 'insert-css'
-import Beachball from 'migme-beachball'
+import Beachball from 'migme-beachball/src'
 import MigButton from '../button'
 import MigPanel from '../panel'
 import css from './me.styl'


### PR DESCRIPTION
This feels like a hack. Workaround for double-include of babel platform.